### PR TITLE
Add `drupal-drush-sql-cli` command

### DIFF
--- a/drupal-mode.el
+++ b/drupal-mode.el
@@ -529,8 +529,6 @@ buffer."
 (defun drupal-drush-sql-cli ()
   "Run a SQL shell using \"drush sql-cli\" in a SQL-mode comint buffer."
   (interactive)
-  (require 'sql)
-  (require 'json)
   (let* ((json-object-type 'plist)
          (config
           (json-read-from-string


### PR DESCRIPTION
This adds a command and keybinding to run `drush sql-cli` in a properly set-up Emacs SQL buffer.

This is fairly lightly tested (e.g., I have not tried using it with anything other than MySQL) so feedback is welcome.