### PR TITLE
Avoid "no tags containing" error in hook skeleton

### DIFF
--- a/drupal-mode.el
+++ b/drupal-mode.el
@@ -556,7 +556,8 @@ buffer."
     (user-error "%s already exists in file." (replace-regexp-in-string "^hook" (drupal-module-name) v2)))
   ;; User error if the hook is already inserted elsewhere.
   (when (and drupal-get-function-args
-             (funcall drupal-get-function-args (replace-regexp-in-string "^hook" (drupal-module-name) v2)))
+             (ignore-errors
+               (funcall drupal-get-function-args (replace-regexp-in-string "^hook" (drupal-module-name) v2))))
     (user-error "%s already exists elsewhere." (replace-regexp-in-string "^hook" (drupal-module-name) v2)))
   (drupal-ensure-newline)
   "/**\n"


### PR DESCRIPTION
The hook implementation skeleton funcalls `drupal-get-function-args` to
check whether the new function implementation already exists elsewhere
in the project.  When the value of this variable is
`drupal/etags-get-function-args`, it throws an error for non-existent
function names, making it impossible to insert a new implementation.
Adding `ignore-errors` around the call fixes this.