### PR TITLE
Handle multisites and site aliases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: emacs-lisp
+before_install:
+  - curl -fsSkL https://gist.githubusercontent.com/rejeep/7736123/raw | sh
+  - export PATH="/home/travis/.cask/bin:$PATH"
+  - export PATH="/home/travis/.evm/bin:$PATH"
+  - evm install $EVM_EMACS --use
+  - cask
+env:
+  - EVM_EMACS=emacs-24.1-bin
+  - EVM_EMACS=emacs-24.2-bin
+  - EVM_EMACS=emacs-24.4-bin
+  - EVM_EMACS=emacs-24.5-bin
+script:
+  - emacs --version
+  - make test

--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ below) and depend on a few through the packaging system
 ## Installation
 
 The easiest way to install Drupal mode is probably to install it via
-the ELPA archive at [Marmalade](http://marmalade-repo.org/packages/drupal-mode).
+the ELPA archive at
+[Marmalade](http://marmalade-repo.org/packages/drupal-mode) or
+[MELPA Stable](http://stable.melpa.org/#/drupal-mode) (if you want
+bleeding edge use regular [MELPA](http://melpa.org/#/drupal-mode)).
 
 ELPA (package.el) is part of Emacs 24. For Emacs 23 see
 [Marmalade](http://marmalade-repo.org) for installation instructions.
@@ -174,7 +177,7 @@ For this to work you need:
 There are quite a few attempts at writing a Drupal mode out in the
 wild:
 
-*    [Search Github for drupal-mode](https://github.com/search?type=Repositories&q="drupal-mode")
+*    [Search Github for drupal-mode](https://github.com/search?l=Emacs+Lisp&q=drupal&type=Repositories)
 *     At drupal.org:
 	* http://drupal.org/sandbox/bartlantz/1405156
 	* http://drupal.org/project/emacs

--- a/drupal-mode.el
+++ b/drupal-mode.el
@@ -1,11 +1,11 @@
 ;;; drupal-mode.el --- Advanced minor mode for Drupal development
 
-;; Copyright (C) 2012, 2013, 2014 Arne Jørgensen
+;; Copyright (C) 2012, 2013, 2014, 2015 Arne Jørgensen
 
 ;; Author: Arne Jørgensen <arne@arnested.dk>
 ;; URL: https://github.com/arnested/drupal-mode
 ;; Created: January 17, 2012
-;; Version: 0.4.0
+;; Version: 0.6.1
 ;; Package-Requires: ((php-mode "1.5.0"))
 ;; Keywords: programming, php, drupal
 
@@ -33,11 +33,15 @@
 
 ;;; Code:
 
+(require 'cl)
 (require 'php-mode)
 (require 'format-spec)
+(require 'json)
+(require 'sql)
 
 ;; Silence byte compiler.
 (defvar css-indent-level)
+(defvar js-indent-level)
 
 
 
@@ -74,7 +78,7 @@ a single newline (\\n)."
 (defcustom drupal-delete-trailing-whitespace 'always
   "Whether to delete all the trailing whitespace across Drupal buffers.
 All whitespace after the last non-whitespace character in a line is deleted.
-This respects narrowing, created by C-x n n and friends.
+This respects narrowing, created by \\[narrow-to-region] and friends.
 A formfeed is not considered whitespace by this function.
 
 If `Always' delete trailing whitespace across drupal mode buffers.
@@ -97,8 +101,7 @@ whitespace at the end."
 %v is the Drupal major version.
 %s is the search term."
   :type '(choice (const :tag "Api.drupal.org" "http://api.drupal.org/api/search/%v/%s")
-                 (const :tag "Api.drupalcontrib.org" "http://api.drupalcontrib.org/api/search/%v/%s")
-                 (const :tag "Api.drupalize.me" "http://api.drupalize.me/api/search/%v/%s")
+                 (const :tag "Drupalcontrib.org" "http://drupalcontrib.org/api/search/%v/%s")
                  (string :tag "Other" "http://example.com/api/search/%v/%s"))
   :link '(url-link :tag "api.drupalcontrib.org" "http://api.drupalcontrib.org")
   :link '(url-link :tag "api.drupal.org" "http://api.drupal.org")
@@ -162,8 +165,20 @@ Include path to the executable if it is not in your $PATH."
   :type '(repeat symbol)
   :group 'drupal)
 
+;;;###autoload
+(defcustom drupal-other-modes (list 'dired-mode)
+  "Other major modes that should enable Drupal mode."
+  :type '(repeat symbol)
+  :group 'drupal)
+
+;;;###autoload
+(defcustom drupal-ignore-paths-regexp "\\(vendor\\|node_modules\\)"
+  "Don't enable Drupal mode per default in files whose path match this regexp."
+  :type 'regexp
+  :group 'drupal)
+
 (defcustom drupal-enable-auto-fill-mode t
-  "Whether to use `auto-fill-mode' Drupal PHP buffers.
+  "Whether to use `auto-fill-mode' in Drupal PHP buffers.
 Drupal mode will only do auto fill in comments (auto filling code
 is not nice).
 
@@ -224,7 +239,9 @@ get better filling in Doxygen comments."
     (?h . drupal-insert-hook)
     (?f . drupal-insert-function)
     (?m . drupal-module-name)
-    (?t . drupal-wrap-string-in-t-function))
+    (?e . drupal-drush-php-eval)
+    (?t . drupal-wrap-string-in-t-function)
+    (?s . drupal-drush-sql-cli))
   "Map of mnemonic keys and functions for keyboard shortcuts.
 See `drupal-mode-map'.")
 
@@ -297,16 +314,12 @@ function arguments.")
     (when (derived-mode-p 'css-mode)
       (set (make-local-variable 'css-indent-level) 2)))
 
+  ;; Stuff special for js-mode buffers.
+  (when (apply 'derived-mode-p drupal-js-modes)
+    (set (make-local-variable 'js-indent-level) 2))
+
   ;; Stuff special for php-mode buffers.
   (when (apply 'derived-mode-p drupal-php-modes)
-    ;; Show function arguments from GNU GLOBAL for function at point
-    ;; after a short delay of idle time.
-    (when (and drupal-get-function-args
-               (fboundp 'eldoc-mode))
-      (set (make-local-variable 'eldoc-documentation-function)
-           #'drupal-eldoc-documentation-function)
-      (eldoc-mode 1))
-
     ;; Set correct comment style for inline comments.
     (setq comment-start "//")
     (setq comment-padding " ")
@@ -330,16 +343,15 @@ function arguments.")
 
 ;; drupal style
 (defcustom drupal-style
-  '((c-basic-offset . 2)
+  '("php"
+    (c-basic-offset . 2)
     (fill-column . 80)
     (show-trailing-whitespace . t)
     (indent-tabs-mode . nil)
     (require-final-newline . t)
     (c-offsets-alist . ((arglist-close . 0)
                         (arglist-cont-nonempty . c-lineup-math)
-                        (arglist-intro . +)
-                        (case-label . +)
-                        (comment-intro . 0)))
+                        (arglist-intro . +)))
     (c-doc-comment-style . (php-mode . javadoc))
     (c-label-minimum-indentation . 1)
     (c-special-indent-hook . c-gnu-impose-minimum)
@@ -369,12 +381,26 @@ of the project)."
   (if (and drupal-rootdir
            drupal-drush-program)
       (let ((root drupal-rootdir))
-        (with-temp-buffer
-          (cd-absolute root)
-          (message "Clearing all caches...")
-          (drupal-call-drush-process nil nil nil "cache-clear" "all")
-          (message "Clearing all caches...done")))
+        (message "Clearing all caches...")
+        (if (fboundp 'async-start-process)
+            (async-start-process "drush cache-clear all" drupal-drush-program '(lambda (process-object) (message "Clearing all caches...done")) (concat "--root=" (expand-file-name root)) "cache-clear" "all")
+          (drupal-call-drush-process nil 0 nil (concat "--root=" (expand-file-name root)) "cache-clear" "all")))
     (message "Can't clear caches. No DRUPAL_ROOT and/or no drush command.")))
+
+(defun drupal-drush-php-eval ()
+  "Evaluate active region with `drush php-eval'."
+  (interactive)
+  (when (and (use-region-p)
+             drupal-rootdir
+             drupal-drush-program)
+    (let ((root drupal-rootdir)
+          (code (buffer-substring (region-beginning) (region-end))))
+      (with-temp-buffer-window
+       "*drush php-eval*" nil nil
+       (message "PHP eval...")
+       (special-mode)
+       (call-process drupal-drush-program nil t nil (concat "--root=" (expand-file-name root)) "php-eval" code)
+       (message "PHP eval...done")))))
 
 (defun drupal-call-drush-process (infile destination display &rest args)
   "Specialized version of `call-process' for Drupal mode.
@@ -427,6 +453,16 @@ INFILE, DESTINATION, and DISPLAY are passed unchanged to `call-process'."
   [menu-bar drupal manual]
   '("Drupal Mode manual" . drupal-mode-manual))
 (define-key drupal-mode-map
+  [menu-bar drupal php-eval]
+  '(menu-item "PHP Evaluate active region" drupal-drush-php-eval
+              :enable (and (use-region-p) drupal-rootdir drupal-drush-program)))
+(define-key drupal-mode-map
+    [menu-bar drupal insert-hook]
+  '("Insert hook implementation" . drupal-insert-hook))
+(define-key drupal-mode-map
+    [menu-bar drupal insert-function]
+  '("Insert function template" . drupal-insert-function))
+(define-key drupal-mode-map
   [menu-bar drupal search-documentation]
   '(menu-item "Search documentation" drupal-search-documentation
               :enable (apply 'derived-mode-p drupal-php-modes)))
@@ -434,6 +470,10 @@ INFILE, DESTINATION, and DISPLAY are passed unchanged to `call-process'."
   [menu-bar drupal cache-clear]
   '(menu-item "Clear all caches" drupal-drush-cache-clear
               :enable (and drupal-rootdir drupal-drush-program)))
+(define-key drupal-mode-map
+  [menu-bar drupal sql-cli]
+  '(menu-item "Open SQL shell" drupal-drush-sql-cli
+    :enable (and drupal-rootdir drupal-drush-program)))
 
 (define-key drupal-mode-map
   [menu-bar drupal drupal-project drupal-project-bugs]
@@ -462,7 +502,7 @@ According to https://drupal.org/coding-standards#indenting you
 should save your files with unix style end of line."
   (when (and drupal-mode
              drupal-convert-line-ending
-             (/= (coding-system-eol-type buffer-file-coding-system) 0))
+             (not (equal (coding-system-eol-type (or coding-system-for-write buffer-file-coding-system)) 0)))
     (if (or (eq drupal-convert-line-ending t)
             (y-or-n-p "Convert to unix style line endings?"))
         (progn
@@ -480,7 +520,10 @@ should save your files with unix style end of line."
        ((and (boundp 'php-extras-function-arguments)
              (hash-table-p php-extras-function-arguments)
              (gethash (symbol-name symbol) php-extras-function-arguments))
-        (php-search-documentation))
+        ;; Older versions of `php-search-documentation' did not take arguments.
+        (condition-case nil
+            (php-search-documentation (symbol-name symbol))
+          (wrong-number-of-arguments (with-no-warnings (php-search-documentation)))))
        ((and drupal-drush-program (string-match "drush" (symbol-name symbol)))
         (browse-url
          (format-spec drupal-drush-search-url `((?v . ,(replace-regexp-in-string "\\([0-9]+\.\\).*\\'" "\\1x" (replace-regexp-in-string ".*-dev" "master" drupal-drush-version)))
@@ -489,22 +532,25 @@ should save your files with unix style end of line."
            (format-spec drupal-search-url `((?v . ,(drupal-major-version drupal-version))
                                             (?s . ,symbol)))))))))
 
+;;;###autoload
 (defun drupal-tail-drupal-debug-txt ()
   "Tail drupal_debug.txt.
 If a drupal_debug.txt exists in the sites temporary directory
 visit it and enable `auto-revert-tail-mode' in the visiting
 buffer."
   (interactive)
-  (when drupal-drush-program
-    (let* ((tmp (ignore-errors
+  (when (and drupal-drush-program
+             drupal-rootdir)
+    (let* ((root drupal-rootdir)
+           (tmp (ignore-errors
                   (replace-regexp-in-string
-                   "[\n\r]" ""
+                   "[\n\r].*" ""
                    (drupal-drush-command-to-string
                     "core-status" "temp" "--pipe" "--format=list" "--strict=0"))))
            (dd (concat tmp "/drupal_debug.txt")))
       (when (file-readable-p dd)
         (find-file-other-window dd)
-        (auto-revert-tail-mode 1)))))
+        (auto-revert-mode 1)))))
 
 (defun drupal-wrap-string-in-t-function ()
   "If point is inside a string wrap the string in the t() function."
@@ -517,6 +563,48 @@ buffer."
         (forward-char)
         (search-forward-regexp "\\(\"\\|'\\)")
         (insert ")")))))
+
+(defun drupal-drush-sql-cli ()
+  "Run a SQL shell using \"drush sql-cli\" in a SQL-mode comint buffer."
+  (interactive)
+  (let* ((json-object-type 'plist)
+         (config
+          (json-read-from-string
+           (with-temp-buffer
+             (call-process drupal-drush-program nil t nil
+                           "sql-conf" "--format=json")
+             (buffer-string)))))
+    (when (not config)
+      (error "No Drupal SQL configuration found."))
+    (destructuring-bind (&key database driver &allow-other-keys) config
+      (let ((sql-interactive-product
+             (drupal--db-driver-to-sql-product driver))
+            (start-buffer (current-buffer))
+            (sqli-buffer
+             (make-comint (format "SQL (%s)" database)
+                          drupal-drush-program nil "sql-cli")))
+        (with-current-buffer sqli-buffer
+          (sql-interactive-mode)
+          (set (make-local-variable 'sql-buffer)
+               (buffer-name (current-buffer)))
+
+          ;; Set `sql-buffer' in the start buffer
+          (with-current-buffer start-buffer
+            (when (derived-mode-p 'sql-mode)
+              (setq sql-buffer (buffer-name sqli-buffer))
+              (run-hooks 'sql-set-sqli-hook)))
+
+          ;; All done.
+          (run-hooks 'sql-login-hook)
+          (pop-to-buffer sqli-buffer))))))
+
+(defun drupal--db-driver-to-sql-product (driver)
+  "Translate a Drupal DB driver name into a sql-mode symbol."
+  (let ((driver (intern driver)))
+    (cond
+      ((eq driver 'pgsql) 'postgres)
+      ((assq driver sql-product-alist) driver)
+      (t 'ansi))))
 
 
 
@@ -533,7 +621,7 @@ buffer."
                              nil nil "hook_"))
   '(setq str v1)
   '(setq v2 (let ((hook v1)
-                  case-fold-search form-id form-id-placeholder)
+                  case-fold-search form-id form-id-placeholder upadte-id update-id-placeholder update-next-id)
               (if (string-match "\\([A-Z][A-Z_]*[A-Z]\\)" hook)
                   (progn
                     (setq form-id-placeholder (match-string 1 hook))
@@ -542,7 +630,22 @@ buffer."
                                    nil 'drupal-form-id-history form-id-placeholder))
                     (setq str (concat hook "() for " form-id))
                     (replace-regexp-in-string (regexp-quote form-id-placeholder) form-id hook t))
-                hook)))
+                (if (string-match "_\\(N\\)\\'" hook)
+                    (progn
+                      (setq update-id-placeholder (match-string 1 hook))
+                      (setq update-id (read-number
+                                       (concat "Implements " hook "(): ") (drupal-next-update-id)))
+                      (replace-regexp-in-string (regexp-quote update-id-placeholder) (number-to-string update-id) hook t))
+                  hook))))
+  ;; User error if the hook is already inserted in the file.
+  (when (and (boundp 'imenu--index-alist)
+             (assoc (replace-regexp-in-string "^hook" (drupal-module-name) v2) (assoc "Named Functions" imenu--index-alist)))
+    (user-error "%s already exists in file." (replace-regexp-in-string "^hook" (drupal-module-name) v2)))
+  ;; User error if the hook is already inserted elsewhere.
+  (when (and drupal-get-function-args
+             (ignore-errors
+               (funcall drupal-get-function-args (replace-regexp-in-string "^hook" (drupal-module-name) v2))))
+    (user-error "%s already exists elsewhere." (replace-regexp-in-string "^hook" (drupal-module-name) v2)))
   (drupal-ensure-newline)
   "/**\n"
   " * Implements " str "().\n"
@@ -550,6 +653,34 @@ buffer."
   "function " (replace-regexp-in-string "^hook" (drupal-module-name) v2) "(" (when drupal-get-function-args (funcall drupal-get-function-args v1 (drupal-major-version))) ") {\n"
   "  " @ _ "\n"
   "}\n")
+
+(defun drupal-next-update-id ()
+  "Find next update ID for hook_update_N().
+See https://api.drupal.org/api/drupal/modules%21system%21system.api.php/function/hook_update_N/7."
+  (let (existing-ids
+        next-id
+        (current-id 0)
+        ;; Lowest possible ID based current Drupal major-version and
+        ;; current module major version.
+        (lowest-possible-id (+ (* (string-to-number (drupal-major-version)) 1000)
+                               (* (string-to-number (drupal-module-major-version :default "1")) 100)
+                               1)))
+    ;; Locate existing ID's in current buffer.
+    (save-excursion
+      (goto-char (point-min))
+      (while (re-search-forward "_update_\\([0-9]+\\)(" nil t)
+        (add-to-list 'existing-ids (string-to-number (match-string-no-properties 1)))))
+    ;; Find the largest of the existing ID's (current ID).
+    (when existing-ids
+      (setq current-id (apply 'max existing-ids)))
+    ;; Bump ID to get next update ID.
+    (setq next-id (+ 1 current-id))
+    ;; If the next ID doesn't match current Drupal major-version and
+    ;; current module major version use ID based on current versions
+    ;; instead.
+    (when (< next-id lowest-possible-id)
+      (setq next-id lowest-possible-id))
+  next-id))
 
 (define-skeleton drupal-insert-function
   "Insert Drupal function skeleton."
@@ -674,20 +805,20 @@ the location of DRUPAL_ROOT."
         (insert-file-contents-literally module)
         (goto-char (point-min))
         (when (and (not drupal-version)
-                   (re-search-forward "^core *=" nil t))
-          (re-search-forward " *\"?\\([^\"]+\\)\"?" (point-at-eol) t)
+                   (re-search-forward "^core[ \t]*=" nil t))
+          (re-search-forward "[ \t]\"?\\([^\"]+\\)\"?" (point-at-eol) t)
           (setq version (match-string-no-properties 1)))
         (goto-char (point-min))
-        (when (re-search-forward "^name *=" nil t)
-          (re-search-forward " *\"?\\([^\"]+\\)\"?" (point-at-eol) t)
+        (when (re-search-forward "^name[ \t]*=" nil t)
+          (re-search-forward "[ \t]*\"?\\([^\"]+\\)\"?" (point-at-eol) t)
           (setq module-name (match-string-no-properties 1)))
         (goto-char (point-min))
-        (when (re-search-forward "^version *=" nil t)
-          (re-search-forward " *\"?\\([^\"]+\\)\"?" (point-at-eol) t)
+        (when (re-search-forward "^version[ \t]*=" nil t)
+          (re-search-forward "[ \t]*\"?\\([^\"]+\\)\"?" (point-at-eol) t)
           (setq module-version (match-string-no-properties 1)))
         (goto-char (point-min))
-        (when (re-search-forward "^project *=" nil t)
-          (re-search-forward " *\"?\\([^\"]+\\)\"?" (point-at-eol) t)
+        (when (re-search-forward "^project[ \t]*=" nil t)
+          (re-search-forward "[ \t]*\"?\\([^\"]+\\)\"?" (point-at-eol) t)
           (setq project (match-string-no-properties 1)))
         (when (and (string= project "drupal")
                    (string= module-version "VERSION"))
@@ -765,7 +896,7 @@ the location of DRUPAL_ROOT."
 (defun drupal-hack-local-variables ()
   "Drupal hack `drupal-local-variables' as buffer local variables."
   (interactive)
-  (let ((dir (expand-file-name (or (file-name-directory buffer-file-name) default-directory)))
+  (let ((dir (expand-file-name (file-name-directory (or buffer-file-name default-directory))))
         matches)
     (maphash (lambda (key value)
                (when (string-match (concat "^" (regexp-quote key)) dir)
@@ -837,6 +968,20 @@ Used in `drupal-insert-hook' and `drupal-insert-function'."
         (insert name)
       name)))
 
+(defun* drupal-module-major-version (&key version default)
+  "Return a modules major version number.
+If VERSION is not set derive it from the buffer local variable
+`drupal-major-version'.
+
+If VERSION (and `drupal-major-version') is nil return DEFAULT."
+  (when (null version)
+    (setq version (or drupal-module-version "")))
+  (let (major-version)
+    (if (string-match "[0-9x\\.]+-\\([0-9]+\\)\\..*" version)
+        (setq major-version (match-string-no-properties 1 version))
+      (setq major-version default))
+  major-version))
+
 (defun drupal-major-version (&optional version)
   "Return major version number of version string.
 If major version number is 4 - return both major and minor."
@@ -857,14 +1002,16 @@ is a mode supported by `drupal-mode' (currently only
 
 The function is suitable for adding to the supported major modes
 mode-hook."
-  (when (apply 'derived-mode-p (append drupal-php-modes drupal-css-modes drupal-js-modes drupal-info-modes))
+  (when (apply 'derived-mode-p (append drupal-php-modes drupal-css-modes drupal-js-modes drupal-info-modes drupal-other-modes))
     (drupal-detect-drupal-version)
-    (when (or drupal-version
-              (string-match "drush" (or buffer-file-name default-directory)))
+    (when (and
+           (or drupal-version
+               (string-match "drush" (or buffer-file-name default-directory)))
+           (not (string-match drupal-ignore-paths-regexp (or buffer-file-name default-directory))))
       (drupal-mode 1))))
 
 ;;;###autoload
-(dolist (mode (append drupal-php-modes drupal-css-modes drupal-js-modes drupal-info-modes))
+(dolist (mode (append drupal-php-modes drupal-css-modes drupal-js-modes drupal-info-modes drupal-other-modes))
   (when (intern (concat (symbol-name mode) "-hook"))
     (add-hook (intern (concat (symbol-name mode) "-hook")) #'drupal-mode-bootstrap)))
 
@@ -876,8 +1023,11 @@ mode-hook."
 
 ;; Load support for various Emacs features if necessary.
 (eval-after-load 'autoinsert '(require 'drupal/autoinsert))
+(eval-after-load 'eldoc '(require 'drupal/eldoc))
 (eval-after-load 'etags '(require 'drupal/etags))
 (eval-after-load 'gtags '(require 'drupal/gtags))
+(eval-after-load 'helm-gtags '(require 'drupal/gtags))
+(eval-after-load 'ggtags '(require 'drupal/ggtags))
 (eval-after-load 'ispell '(require 'drupal/ispell))
 (eval-after-load 'flymake-phpcs '(require 'drupal/flymake-phpcs))
 (eval-after-load 'flycheck '(require 'drupal/flycheck))

--- a/drupal-mode.el
+++ b/drupal-mode.el
@@ -233,6 +233,14 @@ get better filling in Doxygen comments."
 (make-variable-buffer-local 'drupal-project)
 (put 'drupal-project 'safe-local-variable 'string-or-null-p)
 
+(defvar drupal-drush-site-alias nil
+  "Drush site-alias if auto detected or set via `drupal-set-site'.")
+(make-variable-buffer-local 'drupal-drush-site-alias)
+
+(defvar drupal-drush-site-url nil
+  "Drupal base URL if set via `drupal-set-site'.")
+(make-variable-buffer-local 'drupal-drush-site-url)
+
 (defvar drupal-mode-map-alist
   '((?d . drupal-search-documentation)
     (?c . drupal-drush-cache-clear)
@@ -285,12 +293,6 @@ function arguments.")
               (concat " [" drupal-drush-site-url "]")))))
   "Mode line")
 (put 'drupal-mode-line 'risky-local-variable t) ; necessary for (:eval ..)
-
-(defvar drupal-drush-site-alias nil
-  "Drush site-alias if detected.")
-
-(defvar drupal-drush-site-url nil
-  "Base URL to pass to Drush as a \"--uri=\" argument.")
 
 ;;;###autoload
 (define-minor-mode drupal-mode

--- a/drupal-mode.el
+++ b/drupal-mode.el
@@ -854,12 +854,16 @@ the location of DRUPAL_ROOT."
     (drupal-set-dir-local-variable drupal-rootdir 'drupal-drush-site-url url)))
 
 (defun drupal-set-dir-local-variable (dir variable value)
-  (set (make-local-variable variable) value)
-  (let ((alist (copy-alist (gethash dir drupal-local-variables))))
+  (let* ((dir (expand-file-name (file-name-directory dir)))
+         (alist (copy-alist (gethash dir drupal-local-variables))))
     (puthash dir
              (cons `(,variable . ,value)
                    (assq-delete-all variable alist))
-             drupal-local-variables)))
+             drupal-local-variables)
+    (dolist (buffer (buffer-list))
+      (with-current-buffer buffer
+        (when drupal-mode
+          (drupal-hack-local-variables))))))
 
 (defun drupal-read-site-alias-or-url ()
   (let* ((site-aliases

--- a/drupal-mode.el
+++ b/drupal-mode.el
@@ -258,8 +258,16 @@ function arguments.")
 (make-variable-buffer-local 'drupal-get-function-args)
 
 
-(defvar drupal-mode-line " Drupal"
+
+(defvar drupal-mode-line
+  '(" Drupal"
+    (:eval (cond
+             (drupal-drush-site-alias
+              (concat " @" drupal-drush-site-alias))
+             (drupal-drush-site-url
+              (concat " [" drupal-drush-site-url "]")))))
   "Mode line")
+(put 'drupal-mode-line 'risky-local-variable t) ; necessary for (:eval ..)
 
 (defvar drupal-drush-site-alias nil
   "Drush site-alias if detected.")
@@ -692,8 +700,6 @@ the location of DRUPAL_ROOT."
                                                                    (drupal-project . ,project))
                  drupal-local-variables))))
   (drupal-hack-local-variables)
-  (when drupal-drush-site-alias
-    (set (make-local-variable 'drupal-mode-line) (concat drupal-mode-line "@" drupal-drush-site-alias)))
   drupal-version)
 
 (defun drupal-set-site (alias-or-url)

--- a/drupal-mode.el
+++ b/drupal-mode.el
@@ -285,12 +285,12 @@ function arguments.")
 
 
 (defvar drupal-mode-line
-  '(" Drupal"
-    (:eval (cond
-             (drupal-drush-site-alias
-              (concat " @" drupal-drush-site-alias))
-             (drupal-drush-site-url
-              (concat " [" drupal-drush-site-url "]")))))
+  '(:eval (cond
+            (drupal-drush-site-alias
+             (concat " Drupal @" drupal-drush-site-alias))
+            (drupal-drush-site-url
+             (concat " Drupal [" drupal-drush-site-url "]"))
+            (t " Drupal")))
   "Mode line")
 (put 'drupal-mode-line 'risky-local-variable t) ; necessary for (:eval ..)
 

--- a/drupal/eldoc.el
+++ b/drupal/eldoc.el
@@ -1,0 +1,47 @@
+;;; drupal/eldoc.el --- Drupal-mode support for eldoc.el
+
+;; Copyright (C) 2015 Arne Jørgensen
+
+;; Author: Arne Jørgensen <arne@arnested.dk>
+
+;; This file is part of Drupal mode.
+
+;; Drupal mode is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+
+;; Drupal mode is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with Drupal mode.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Enable drupal-mode support for eldoc.
+
+;;; Code:
+
+(defun drupal/eldoc-enable ()
+  "Enable eldoc in PHP files."
+  (when (apply 'derived-mode-p drupal-php-modes)
+    ;; Show function arguments from GNU GLOBAL for function at point
+    ;; after a short delay of idle time.
+    (when (fboundp 'eldoc-mode)
+      (set (make-local-variable 'eldoc-documentation-function)
+           #'drupal-eldoc-documentation-function)
+      (eldoc-mode 1))))
+
+(add-hook 'drupal-mode-hook #'drupal/eldoc-enable)
+
+(when drupal-mode
+  (drupal/eldoc-enable))
+
+
+
+(provide 'drupal/eldoc)
+
+;;; drupal/eldoc.el ends here

--- a/drupal/emacs-drush.el
+++ b/drupal/emacs-drush.el
@@ -1,6 +1,6 @@
 ;;; drupal/emacs-drush.el --- Drupal-mode support for Drush utilities for Emacs users
 
-;; Copyright (C) 2012, 2013 Arne Jørgensen
+;; Copyright (C) 2012, 2013, 2015 Arne Jørgensen
 
 ;; Author: Arne Jørgensen <arne@arnested.dk>
 
@@ -32,7 +32,9 @@
 ;;; Code:
 
 (defcustom drupal/emacs-drush-update-tags-after-save
-  (and drupal-drush-program
+  (and (unless (not (boundp 'gtags-auto-update))
+         gtags-auto-update)
+       drupal-drush-program
        (zerop (call-process drupal-drush-program nil nil nil "help" "etags")))
   "Use `Drush utilities for Emacs users' to run etags/gtags after save.
 On `after-save-hook' run `drush etags' or `drush gtags'.

--- a/drupal/etags.el
+++ b/drupal/etags.el
@@ -47,12 +47,13 @@
   "Get function arguments from etags TAGS."
   (when (and (boundp 'drupal/etags-rootdir)
              (file-exists-p (concat drupal/etags-rootdir "TAGS")))
-    (with-current-buffer (find-tag-noselect symbol nil nil)
-      (goto-char (point-min))
-      (when (re-search-forward
-             (format "function\\s-+%s\\s-*(\\([^{]*\\))" symbol)
-             nil t)
-        (match-string-no-properties 1)))))
+    (save-excursion
+     (with-current-buffer (find-tag-noselect symbol nil nil)
+       (goto-char (point-min))
+       (when (re-search-forward
+              (format "function\\s-+%s\\s-*(\\([^{]*\\))" symbol)
+              nil t)
+         (match-string-no-properties 1))))))
 
 (add-hook 'drupal-mode-hook #'drupal/etags-enable)
 

--- a/drupal/flycheck.el
+++ b/drupal/flycheck.el
@@ -28,20 +28,12 @@
 (require 'flycheck)
 (require 'drupal/phpcs)
 
-(defcustom drupal/flycheck-phpcs-js-and-css t
-  "When Non-nil, override Flycheck to use PHPCS for checking CSS and JavaScript files instead of the checkers configured for css-mode and js-mode."
-  :type `(choice
-          (const :tag "Yes" t)
-          (const :tag "No" nil))
-  :group 'drupal)
-
 (defun drupal/flycheck-hook ()
   "Enable drupal-mode support for flycheck."
-  (when (and (apply 'derived-mode-p (append drupal-php-modes drupal-css-modes drupal-js-modes))
-             drupal/phpcs-standard)
-    ;; Set the coding standard to "Drupal" (we checked that it is
-    ;; supported above.
-    (setq flycheck-phpcs-standard drupal/phpcs-standard)
+  (when (and drupal-mode drupal/phpcs-standard)
+    ;; Set the coding standard to "Drupal" (phpcs.el has checked that
+    ;; it's supported).
+    (set (make-local-variable 'flycheck-phpcs-standard) drupal/phpcs-standard)
 
     ;; Flycheck will also highlight trailing whitespace as an
     ;; error so no need to highlight it twice.
@@ -50,16 +42,16 @@
 
 (add-hook 'drupal-mode-hook #'drupal/flycheck-hook)
 
-(flycheck-define-checker css-js-phpcs
-  "Check CSS and JavaScript  using PHP_CodeSniffer.
+(flycheck-define-checker drupal-phpcs
+  "Check non-PHP Drupal files using PHP_CodeSniffer.
 
-PHP_CodeSniffer can be used to check non-PHP files, as exemplified by the
-Drupal code sniffer.
+The Drupal standard includes checks for non-PHP files, this
+checker runs those.
 
 See URL `http://pear.php.net/package/PHP_CodeSniffer/'."
   :command ("phpcs" "--report=emacs"
-            (option "--standard=" flycheck-phpcs-standard)
-            source)
+            (option "--standard=" flycheck-phpcs-standard concat)
+            source-inplace)
   ;; Though phpcs supports Checkstyle output which we could feed to
   ;; `flycheck-parse-checkstyle', we are still using error patterns here,
   ;; because PHP has notoriously unstable output habits.  See URL
@@ -72,11 +64,19 @@ See URL `http://pear.php.net/package/PHP_CodeSniffer/'."
    (warning line-start
             (file-name) ":" line ":" column ": warning - " (message)
             line-end))
-  :modes (css-mode js-mode)
+  ;; We'd prefer to just check drupal-mode, but flycheck global mode
+  ;; finds the checker before we get a chance to set drupal-mode.
   :predicate (lambda ()
-               (and drupal/flycheck-phpcs-js-and-css (apply 'derived-mode-p (append drupal-php-modes drupal-css-modes drupal-js-modes)))))
+               (apply 'derived-mode-p (append drupal-css-modes drupal-js-modes drupal-info-modes))))
 
-(add-to-list 'flycheck-checkers 'css-js-phpcs)
+;; Append our custom checker.
+(add-to-list 'flycheck-checkers 'drupal-phpcs t)
+;; Add our checker as next-checker to checkers of all supported modes.
+(let ((modes (append drupal-css-modes drupal-js-modes drupal-info-modes)))
+  (dolist (checker (flycheck-defined-checkers))
+          (dolist (mode (flycheck-checker-get checker 'modes))
+                  (if (memq mode modes)
+                      (flycheck-add-next-checker checker 'drupal-phpcs)))))
 
 
 (provide 'drupal/flycheck)

--- a/drupal/flymake-phpcs.el
+++ b/drupal/flymake-phpcs.el
@@ -39,13 +39,13 @@
 ;; https://github.com/illusori/emacs-flymake.
 (when (or (boundp 'flymake-run-in-place)
           (fboundp 'flymake-phpcs-load))
-  (defcustom drupal/flymake-phpcs-run-in-place t
+  (defcustom drupal/flymake-phpcs-run-in-place 'auto
     "If nil, flymake will run on copies in `temporary-file-directory' rather
 than the same directory as the original file.
 
 Drupal Coder Sniffer has some sniffs that will only work if run in place.
 
-Defaults to `t'. Set to `default' to use whatever
+Defaults to t. Set to `default' to use whatever
 `flymake-run-in-place' is set to.
 
 When editing a remote file via Tramp, this flag also has the side-effect of
@@ -55,6 +55,7 @@ file (and thus on the remote machine), or in the same place as
     :type `(choice
             (const :tag "Yes" t)
             (const :tag "No" nil)
+            (const :tag "Auto" auto)
             (const :tag "Default" default))
     :link '(url-link :tag "Drupal Coder Sniffer" "https://drupal.org/project/coder")
     :group 'drupal))
@@ -77,7 +78,10 @@ file (and thus on the remote machine), or in the same place as
         (if drupal/flymake-phpcs-run-in-place
             (set (make-local-variable 'flymake-phpcs-location) 'inplace)
           (set (make-local-variable 'flymake-phpcs-location) 'tempdir)))
-      (set (make-local-variable 'flymake-run-in-place) drupal/flymake-phpcs-run-in-place))
+      (if (and (eq drupal/flymake-phpcs-run-in-place 'auto)
+                 (string-match "\\.info\\'" (or buffer-file-name (buffer-name))))
+          (set (make-local-variable 'flymake-run-in-place) t)
+        (set (make-local-variable 'flymake-run-in-place) nil)))
 
     ;; Flymake-phpcs will also highlight trailing whitespace as an
     ;; error so no need to highlight it twice.
@@ -156,7 +160,8 @@ copy."
                         (match-string-no-properties 0)
                       (file-name-extension file-name t)))
          (base-name (file-name-nondirectory (replace-regexp-in-string (concat (regexp-quote extension) "\\'") "" file-name)))
-         (temp-name (file-truename (make-temp-file (concat base-name "._" prefix) nil extension))))
+         (temp-dir (file-truename (make-temp-file base-name t nil)))
+         (temp-name (file-truename (concat temp-dir "/" file-name))))
     (flymake-log 3 "create-temp-intemp: file=%s temp=%s" file-name temp-name)
     temp-name))
 

--- a/drupal/ggtags.el
+++ b/drupal/ggtags.el
@@ -1,0 +1,62 @@
+;;; drupal/ggtags.el --- Drupal-mode support for ggtags.el
+
+;; Copyright (C) 2012, 2013, 2014 Arne Jørgensen
+
+;; Author: Arne Jørgensen <arne@arnested.dk>
+
+;; This file is part of Drupal mode.
+
+;; Drupal mode is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+
+;; Drupal mode is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with Drupal mode.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Enable drupal-mode support for gtags.
+
+;;; Code:
+
+(require 'ggtags)
+
+(defvar drupal/ggtags-global-command (executable-find "global")
+  "Name of the GNU GLOBAL `global' executable.
+Include path to the executable if it is not in your $PATH.")
+
+(defun drupal/ggtags-enable ()
+  "Setup rootdir for gtags."
+  (let ((dir (locate-dominating-file (or buffer-file-name default-directory) "GTAGS")))
+    (when dir
+      (ggtags-mode 1)
+      ;; Connect `drupal-symbol-collection' to `ggtags-mode'
+      ;; completion
+      (setq drupal-symbol-collection
+            (lambda () (all-completions "" ggtags-completion-table)))
+      (setq drupal-get-function-args #'drupal/ggtags-get-function-args))))
+
+(defun drupal/ggtags-get-function-args (symbol &optional version)
+  "Get function arguments from GNU GLOBAL."
+  (when (and (boundp 'ggtags-project-root)
+             (file-exists-p (expand-file-name "GTAGS" ggtags-project-root)))
+    (with-temp-buffer
+      (ignore-errors
+        (call-process drupal/ggtags-global-command nil t nil "-x" symbol)
+        (goto-char (point-min))
+        (search-forward-regexp "[^(]*(\\(.*\\))[^)]*" nil t)
+        (match-string-no-properties 1)))))
+
+(add-hook 'drupal-mode-hook #'drupal/ggtags-enable)
+
+
+
+(provide 'drupal/ggtags)
+
+;;; drupal/ggtags.el ends here

--- a/drush-make-mode.el
+++ b/drush-make-mode.el
@@ -27,6 +27,7 @@
 ;;; Code:
 
 (require 'bug-reference)
+(require 'imenu)
 
 ;;;###autoload
 (define-derived-mode drush-make-mode conf-windows-mode "Drush Make"


### PR DESCRIPTION
This pull request is based on the work in #18 to make drush commands support site aliases.  It also allows drupal-mode to work better with multisite installations.  (I dislike multisite setups, but sometimes have to deal with them…)

It adds a concept of the "current site", which can be specified either using a site alias or a parameter to `--uri`.  It also refactors all Drush calls so that they go through a standard interface which respects these parameters.

The "current site" setting is common to all buffers within the same project.  It should be detected automatically, and can be changed using a command (`M-x drupal-set-site`) or via the menubar.

This has received only light testing, but it seems to work, so I wanted to open a PR to allow others to potentially test and review it.  (Also happy to add more ERT tests, etc.)