### PR TITLE
Hardcode the Drupal coding standard name

### DIFF
--- a/drupal/phpcs.el
+++ b/drupal/phpcs.el
@@ -34,8 +34,7 @@
                          ;; command. Check for both.
                          (call-process (or (and (boundp 'flymake-phpcs-command) (executable-find flymake-phpcs-command)) (executable-find "phpcs")) nil (list t nil) nil "-i")))))
       (when (string-match
-             "\\(Drupal[^,
-]*\\)"
+             "Drupal"
              standards)
         (match-string-no-properties 1 standards))))
   "Name of Drupal coding standard rules for PHP CodeSniffer.


### PR DESCRIPTION
If I do this, Drupal mode, flycheck and phpcs work happily together. If I don't, I get errors that `Drupal and DrupalPractice coding standard not found`, and if I manually remove the `DrupalPractice` code sniff style, I get `Drupal and PSR1 coding standard not found`.