### PR TITLE
Fix phpcs output parsing

### DIFF
--- a/drupal/phpcs.el
+++ b/drupal/phpcs.el
@@ -1,6 +1,6 @@
 ;;; drupal/phpcs.el --- Drupal-mode common support for flymake-phpcs and flycheck
 
-;; Copyright (C) 2012, 2013 Arne Jørgensen
+;; Copyright (C) 2012, 2013, 2016 Arne Jørgensen
 
 ;; Author: Arne Jørgensen <arne@arnested.dk>
 
@@ -34,7 +34,7 @@
                          ;; command. Check for both.
                          (call-process (or (and (boundp 'flymake-phpcs-command) (executable-find flymake-phpcs-command)) (executable-find "phpcs")) nil (list t nil) nil "-i")))))
       (when (string-match
-             "\\(Drupal[^,
+             "\\(Drupal[^ ,
 ]*\\)"
              standards)
         (match-string-no-properties 1 standards))))


### PR DESCRIPTION
We couldn't catch the Drupal standard if it was the next to last standard as in:
```
The installed coding standards are MySource, PSR2, Zend, Squiz, PHPCS, PEAR, Drupal and PSR1
```
Maybe there used to be an Oxford comma in the output of `phpcs`? Or maybe we have always been failing on this.

Fixes #71.