### PR TITLE
Use proper indent for continuation lines

### DIFF
--- a/drupal-mode.el
+++ b/drupal-mode.el
@@ -340,6 +340,7 @@ function arguments.")
     (c-doc-comment-style . (php-mode . javadoc))
     (c-label-minimum-indentation . 1)
     (c-special-indent-hook . c-gnu-impose-minimum)
+    (statement-cont . +)
     )
   "Drupal coding style.
 According to https://drupal.org/coding-standards#indenting."


### PR DESCRIPTION
This properly indents this:
```php
$var->func()
  ->func();
```
Which is proper for D8, and I belive it was not specified for D7.
