### PR TITLE
Fix c-basic-offset, indent-tabs-mode, and more

### DIFF
--- a/drupal-mode.el
+++ b/drupal-mode.el
@@ -310,7 +310,7 @@ function arguments.")
     (setq comment-end "")
 
     ;; Setup cc-mode style stuff.
-    (when (derived-mode-p 'c-mode)
+    (when (or (derived-mode-p 'php-base-mode) (derived-mode-p 'c-mode))
       (c-add-language 'drupal-mode 'c-mode)
       (c-set-style "drupal"))
 


### PR DESCRIPTION
php-mode is no longer based on c-mode, but php-base-mode (see
https://github.com/emacs-php/php-mode/pull/772).

This prevented the drupal style to be used.
